### PR TITLE
a2x fix

### DIFF
--- a/man/notedeln.1
+++ b/man/notedeln.1
@@ -1,13 +1,13 @@
 '\" t
-.\"     Title: noted
+.\"     Title: notedeln
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/10/2021
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 03/26/2023
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "NOTED" "1" "05/10/2021" "\ \&" "\ \&"
+.TH "NOTEDELN" "1" "03/26/2023" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,19 +28,19 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-noted \- Noted ELN Electronic Lab Notebook
+notedeln \- NotedELN Electronic Lab Notebook
 .SH "SYNOPSIS"
 .sp
-\fBnoted\fR [\fINOTEBOOK\fR]
+\fBnotedeln\fR [\fINOTEBOOK\fR]
 .SH "DESCRIPTION"
 .sp
-The \fBnoted\fR(1) command starts the Noted ELN Electronic Lab Notebook editor\&. Without arguments it presents a splash screen from which a notebook can be selected\&. With argument, it loads up the specified notebook\&.
+The \fBnotedeln\fR(1) command starts the NotedELN Electronic Lab Notebook editor\&. Without arguments it presents a splash screen from which a notebook can be selected\&. With argument, it loads up the specified notebook\&.
 .SH "OPTIONS"
 .sp
 None\&.
 .SH "BUGS"
 .sp
-Noted ELN is fairly mature and used daily in our lab\&. Noted ELN has never caused anyone to lose any data or notes\&. However, there may be bugs\&. Please contact the author if one bites you\&.
+NotedELN has been used daily in our lab for 8 years now\&. NotedELN has never caused anyone to lose any data or notes\&. However, there may be bugs\&. Please contact the author if one bites you\&.
 .SH "AUTHOR"
 .sp
 Daniel Wagenaar <daw@caltech\&.edu>, Division of Biology and Biological Engineering, California Institute of Technology\&. https://www\&.danielwagenaar\&.net\&.

--- a/man/notedeln.1.txt
+++ b/man/notedeln.1.txt
@@ -1,5 +1,5 @@
 NOTEDELN(1)
-======
+===========
 :doctype: manpage
 
 NAME

--- a/man/webgrab.1
+++ b/man/webgrab.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: webgrab
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/10/2021
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 03/26/2023
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "WEBGRAB" "1" "05/10/2021" "\ \&" "\ \&"
+.TH "WEBGRAB" "1" "03/26/2023" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -59,4 +59,4 @@ There may be bugs\&. Please contact the author if one bites you\&.
 Daniel Wagenaar <daw@caltech\&.edu>, Division of Biology and Biological Engineering, California Institute of Technology\&. https://www\&.danielwagenaar\&.net\&.
 .SH "SEE ALSO"
 .sp
-\fBnoted\fR(1)
+\fBnotedeln\fR(1)


### PR DESCRIPTION
This error
```
$ make -B notedeln.1
a2x --doctype manpage --format manpage --no-xmllint --destination-dir=. notedeln.1.txt
asciidoc: FAILED: manpage document title is mandatory
make: *** [Makefile:4: notedeln.1] Error 1

$ head -2 notedeln.1.txt 
NOTEDELN(1)
======
```
can be fixed by extending the line of `=`s to match the length of the previous line.